### PR TITLE
Better use of microtime floats (issue #217)

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -812,8 +812,8 @@ class icit_srdb {
 						 'rows' => 0,
 						 'change' => 0,
 						 'updates' => 0,
-						 'start' => (float)microtime(),
-						 'end' => (float)microtime(),
+						 'start' => microtime(true),
+						 'end' => microtime(true),
 						 'errors' => array( ),
 						 'table_reports' => array( )
 						 );
@@ -823,8 +823,8 @@ class icit_srdb {
 						 'change' => 0,
 						 'changes' => array( ),
 						 'updates' => 0,
-						 'start' => (float)microtime(),
-						 'end' => (float)microtime(),
+						 'start' => microtime(true),
+						 'end' => microtime(true),
 						 'errors' => array( ),
 						 );
 
@@ -872,7 +872,7 @@ class icit_srdb {
 
 				// create new table report instance
 				$new_table_report = $table_report;
-				$new_table_report[ 'start' ] = (float)microtime();
+				$new_table_report[ 'start' ] = microtime(true);
 
 				$this->log( 'search_replace_table_start', $table, $search, $replace );
 
@@ -971,7 +971,7 @@ class icit_srdb {
 
 				}
 
-				$new_table_report[ 'end' ] = (float)microtime();
+				$new_table_report[ 'end' ] = microtime(true);
 
 				// store table report in main
 				$report[ 'table_reports' ][ $table ] = $new_table_report;
@@ -982,7 +982,7 @@ class icit_srdb {
 
 		}
 
-		$report[ 'end' ] = (float)microtime();
+		$report[ 'end' ] = microtime(true);
 
 		$this->log( 'search_replace_end', $search, $replace, $report );
 


### PR DESCRIPTION
`(float)microtime()` and `microtime(true)` aren't the same:

```php
<?php
var_dump(microtime());
var_dump(microtime(true));
var_dump((float)microtime());
```

On PHP 7.2.10 produces:

```
string(21) "0.87200500 1539072995"
float(1539072995.872)
float(0.872034)
```