### PR TITLE
PHP 7.3 compatibility (task #10081)

### DIFF
--- a/srdb.class.php
+++ b/srdb.class.php
@@ -851,7 +851,6 @@ class icit_srdb {
 					case 'utf32':
 						//$encoding = 'utf8';
 						$this->add_error( "The table \"{$table}\" is encoded using \"{$encoding}\" which is currently unsupported.", 'results' );
-						continue;
 						break;
 
 					default:


### PR DESCRIPTION
Minor change which removes unnecessary continue statement which is equivalent to the 'break' statement on the line below. 
(task #10081)